### PR TITLE
Turn ire into a library crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ tokio-timer = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.5"
+
+[features]
+nightly = []

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,46 +1,16 @@
-extern crate aesti;
-#[macro_use]
-extern crate arrayref;
-extern crate byteorder;
-extern crate bytes;
-extern crate clap;
-extern crate cookie_factory;
-extern crate data_encoding;
-extern crate ed25519_dalek;
-extern crate env_logger;
-extern crate flate2;
-#[macro_use]
-extern crate futures;
-extern crate i2p_snow;
-extern crate itertools;
-#[macro_use]
-extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate nom;
-extern crate num;
-extern crate rand;
-extern crate sha2;
-extern crate siphasher;
-extern crate tokio;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_timer;
 
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
+extern crate clap;
+extern crate env_logger;
+extern crate futures;
+extern crate ire;
+extern crate tokio;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use futures::Future;
+use ire::{data, i2np, transport};
 use std::io;
-
-mod constants;
-mod crypto;
-mod data;
-mod i2np;
-mod transport;
 
 fn main() {
     env_logger::init();

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,3 +1,5 @@
+//! Cryptographic types and operations.
+
 use aesti::Aes;
 use ed25519_dalek::Keypair as EdKeypair;
 use ed25519_dalek::PublicKey as EdPublicKey;
@@ -18,6 +20,7 @@ pub mod math;
 
 pub const AES_BLOCK_SIZE: usize = 16;
 
+/// Errors that can occur during creation or verification of a Signature.
 pub enum SignatureError {
     NoSignature,
     TypeMismatch,
@@ -30,6 +33,7 @@ impl From<EdSignatureError> for SignatureError {
     }
 }
 
+/// Various signature algorithms present on the network.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SigType {
     DsaSha1,
@@ -108,6 +112,7 @@ impl SigType {
     }
 }
 
+/// Various encryption algorithms present on the network.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EncType {
     ElGamal2048,
@@ -140,6 +145,8 @@ impl EncType {
 // Key material and signatures
 //
 
+/// The public component of an ElGamal encryption keypair. Represents only the
+/// exponent, not the primes (which are constants).
 pub struct PublicKey(pub [u8; 256]);
 
 impl PublicKey {
@@ -181,6 +188,7 @@ impl PartialEq for PublicKey {
     }
 }
 
+/// The private component of an ElGamal encryption keypair.
 pub struct PrivateKey(pub [u8; 256]);
 
 impl PrivateKey {
@@ -210,6 +218,7 @@ impl fmt::Debug for PrivateKey {
     }
 }
 
+/// The public component of a signature keypair.
 #[derive(Clone, Debug, PartialEq)]
 pub enum SigningPublicKey {
     DsaSha1,
@@ -285,6 +294,7 @@ impl SigningPublicKey {
     }
 }
 
+/// The private component of a signature keypair.
 pub enum SigningPrivateKey {
     DsaSha1,
     EcdsaSha256P256,
@@ -367,6 +377,7 @@ impl Clone for SigningPrivateKey {
     }
 }
 
+/// A signature over some data.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Signature {
     DsaSha1,
@@ -398,6 +409,7 @@ impl Signature {
     }
 }
 
+/// A symmetric key used for AES-256 encryption.
 pub struct SessionKey(pub [u8; 32]);
 
 impl SessionKey {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,10 +15,10 @@ use std::fmt;
 
 use constants;
 
-pub mod frame;
-pub mod math;
+pub(crate) mod frame;
+pub(crate) mod math;
 
-pub const AES_BLOCK_SIZE: usize = 16;
+pub(crate) const AES_BLOCK_SIZE: usize = 16;
 
 /// Errors that can occur during creation or verification of a Signature.
 pub enum SignatureError {
@@ -425,7 +425,7 @@ impl SessionKey {
 //
 
 // TODO: Use aesni if available
-pub struct Aes256 {
+pub(crate) struct Aes256 {
     ti: Aes,
     buf: [u8; AES_BLOCK_SIZE],
     iv_enc: [u8; AES_BLOCK_SIZE],

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,3 +1,7 @@
+//! Various datatypes common to all I2P protocols.
+//!
+//! [Common structures specification](https://geti2p.net/spec/common-structures)
+
 use cookie_factory::GenError;
 use nom::{Err, IResult};
 use rand::{self, Rng};
@@ -22,6 +26,7 @@ pub mod frame;
 // Simple data types
 //
 
+/// The SHA-256 hash of some data.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Hash(pub [u8; 32]);
 
@@ -64,6 +69,7 @@ impl I2PDate {
     }
 }
 
+/// A UTF-8-encoded string.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct I2PString(pub String);
 
@@ -77,9 +83,11 @@ impl I2PString {
     }
 }
 
+/// A set of key/value mappings or properties.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mapping(pub HashMap<I2PString, I2PString>);
 
+/// A random number.
 pub struct SessionTag(pub [u8; 32]);
 
 impl SessionTag {
@@ -90,9 +98,19 @@ impl SessionTag {
     }
 }
 
+/// Defines an identifier that is unique to each router in a tunnel. A TunnelId
+/// is generally greater than zero; do not use a value of zero except in
+/// special cases.
 #[derive(Debug)]
 pub struct TunnelId(pub u32);
 
+/// A key certificate provides a mechanism to indicate the type of the PublicKey
+/// and SigningPublicKey in the Destination or RouterIdentity, and to package
+/// any key data in excess of the standard lengths.
+///
+/// By maintaining exactly 384 bytes before the certificate, and putting any
+/// excess key data inside the certificate, we maintain compatibility for any
+/// software that parses Destinations and RouterIdentities.
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyCertificate {
     pub sig_type: SigType,
@@ -101,6 +119,8 @@ pub struct KeyCertificate {
     enc_data: Vec<u8>,
 }
 
+/// A container for various receipts or proof of works used throughout the I2P
+/// network.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Certificate {
     Null,
@@ -132,6 +152,7 @@ impl Certificate {
     }
 }
 
+/// Defines the way to uniquely identify a particular router.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RouterIdentity {
     public_key: PublicKey,
@@ -219,6 +240,7 @@ impl RouterIdentity {
     }
 }
 
+/// Key material for a RouterIdentity.
 pub struct RouterSecretKeys {
     pub rid: RouterIdentity,
     private_key: PrivateKey,
@@ -279,6 +301,8 @@ impl RouterSecretKeys {
     }
 }
 
+/// A Destination defines a particular endpoint to which messages can be
+/// directed for secure delivery.
 pub struct Destination {
     public_key: PublicKey,
     padding: Option<Vec<u8>>,
@@ -286,12 +310,22 @@ pub struct Destination {
     certificate: Certificate,
 }
 
+/// Defines the authorization for a particular tunnel to receive messages
+/// targeting a Destination.
 pub struct Lease {
     tunnel_gw: Hash,
     tid: TunnelId,
     end_date: I2PDate,
 }
 
+/// Contains all of the currently authorized Leases for a particular Destination,
+/// the PublicKey to which garlic messages can be encrypted, and then the
+/// SigningPublicKey that can be used to revoke this particular version of the
+/// structure.
+///
+/// The LeaseSet is one of the two structures stored in the network database
+/// (the other being RouterInfo), and is keyed under the SHA-256 of the contained
+/// Destination.
 pub struct LeaseSet {
     dest: Destination,
     enc_key: PublicKey,
@@ -300,6 +334,7 @@ pub struct LeaseSet {
     sig: Signature,
 }
 
+/// Defines the means to contact a router through a transport protocol.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RouterAddress {
     cost: u8,
@@ -348,6 +383,12 @@ impl RouterAddress {
     }
 }
 
+/// Defines all of the data that a router wants to publish for the network to
+/// see.
+///
+/// The RouterInfo is one of two structures stored in the network database (the
+/// other being LeaseSet), and is keyed under the SHA-256 of the contained
+/// RouterIdentity.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RouterInfo {
     pub router_id: RouterIdentity,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -20,7 +20,7 @@ use crypto::{
     SigningPublicKey,
 };
 
-pub mod frame;
+pub(crate) mod frame;
 
 //
 // Simple data types

--- a/src/i2np/mod.rs
+++ b/src/i2np/mod.rs
@@ -214,6 +214,15 @@ impl PartialEq for Message {
 }
 
 impl Message {
+    pub fn from_payload(payload: MessagePayload) -> Self {
+        // TODO Random id, correct expiration
+        Message {
+            id: 0,
+            expiration: I2PDate::from_system_time(SystemTime::now()),
+            payload,
+        }
+    }
+
     pub fn dummy_data() -> Self {
         Message {
             id: 0,

--- a/src/i2np/mod.rs
+++ b/src/i2np/mod.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use crypto::SessionKey;
 use data::{Certificate, Hash, I2PDate, LeaseSet, RouterInfo, SessionTag, TunnelId};
 
-pub mod frame;
+pub(crate) mod frame;
 
 //
 // Common structures
@@ -60,7 +60,7 @@ enum DatabaseStoreData {
 
 /// An unsolicited database store, or the response to a successful DatabaseLookup
 /// message.
-pub(crate) struct DatabaseStore {
+pub struct DatabaseStore {
     key: Hash,
     ds_type: u8,
     reply: Option<ReplyPath>,
@@ -75,7 +75,7 @@ struct DatabaseLookupFlags {
 
 /// A request to look up an item in the network database. The response is either
 /// a DatabaseStore or a DatabaseSearchReply.
-pub(crate) struct DatabaseLookup {
+pub struct DatabaseLookup {
     key: Hash,
     from: Hash,
     flags: DatabaseLookupFlags,
@@ -87,7 +87,7 @@ pub(crate) struct DatabaseLookup {
 
 /// The response to a failed DatabaseLookup message, containing a list of router
 /// hashes closest to the requested key.
-pub(crate) struct DatabaseSearchReply {
+pub struct DatabaseSearchReply {
     key: Hash,
     peers: Vec<Hash>,
     from: Hash,
@@ -96,7 +96,7 @@ pub(crate) struct DatabaseSearchReply {
 /// A simple message acknowledgment. Generally created by the message originator,
 /// and wrapped in a Garlic message with the message itself, to be returned by
 /// the destination.
-pub(crate) struct DeliveryStatus {
+pub struct DeliveryStatus {
     msg_id: u32,
     time_stamp: I2PDate,
 }
@@ -119,7 +119,7 @@ pub struct GarlicClove {
 }
 
 /// Used to wrap multiple encrypted I2NP messages.
-pub(crate) struct Garlic {
+pub struct Garlic {
     cloves: Vec<GarlicClove>,
     cert: Certificate,
     msg_id: u32,
@@ -129,7 +129,7 @@ pub(crate) struct Garlic {
 /// A message sent from a tunnel's gateway or participant to the next participant
 /// or endpoint. The data is of fixed length, containing I2NP messages that are
 /// fragmented, batched, padded, and encrypted.
-pub(crate) struct TunnelData {
+pub struct TunnelData {
     tid: TunnelId,
     data: [u8; 1024],
 }
@@ -144,12 +144,12 @@ impl TunnelData {
 
 /// Wraps another I2NP message to be sent into a tunnel at the tunnel's inbound
 /// gateway.
-pub(crate) struct TunnelGateway {
+pub struct TunnelGateway {
     tid: TunnelId,
     data: Vec<u8>,
 }
 
-pub(crate) enum MessagePayload {
+pub enum MessagePayload {
     DatabaseStore(DatabaseStore),
     DatabaseLookup(DatabaseLookup),
     DatabaseSearchReply(DatabaseSearchReply),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! An I2P router implementation in Rust.
+
 #[macro_use]
 extern crate arrayref;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate arrayref;
+#[macro_use]
+extern crate futures;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate nom;
+
+extern crate aesti;
+extern crate byteorder;
+extern crate bytes;
+extern crate cookie_factory;
+extern crate data_encoding;
+extern crate ed25519_dalek;
+extern crate flate2;
+extern crate i2p_snow;
+extern crate itertools;
+extern crate num;
+extern crate rand;
+extern crate sha2;
+extern crate siphasher;
+extern crate tokio;
+extern crate tokio_codec;
+extern crate tokio_io;
+extern crate tokio_timer;
+
+#[cfg(test)]
+#[macro_use]
+extern crate pretty_assertions;
+
+mod constants;
+mod crypto;
+pub mod data;
+pub mod i2np;
+pub mod transport;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate tokio_timer;
 extern crate pretty_assertions;
 
 mod constants;
-mod crypto;
+pub mod crypto;
 pub mod data;
 pub mod i2np;
 pub mod transport;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(test, feature = "nightly"), feature(test))]
+
 //! An I2P router implementation in Rust.
 
 #[macro_use]
@@ -32,6 +34,8 @@ extern crate tokio_timer;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+#[cfg(all(test, feature = "nightly"))]
+extern crate test;
 
 mod constants;
 pub mod crypto;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,3 +1,5 @@
+//! Transports used for point-to-point communication between I2P routers.
+
 use num::bigint::{BigUint, RandBigInt};
 use rand;
 use std::iter::repeat;

--- a/src/transport/ntcp/mod.rs
+++ b/src/transport/ntcp/mod.rs
@@ -1,3 +1,7 @@
+//! A legacy authenticated key agreement protocol over TCP.
+//!
+//! [NTCP specification](https://geti2p.net/en/docs/transport/ntcp)
+
 use bytes::BytesMut;
 use cookie_factory::GenError;
 use futures::{Future, Poll, Stream};

--- a/src/transport/ntcp/mod.rs
+++ b/src/transport/ntcp/mod.rs
@@ -25,7 +25,7 @@ mod frame;
 mod handshake;
 
 lazy_static! {
-    pub static ref NTCP_STYLE: I2PString = I2PString::new("NTCP");
+    pub(super) static ref NTCP_STYLE: I2PString = I2PString::new("NTCP");
 }
 
 // Max NTCP message size is 16kB

--- a/src/transport/ntcp2/handshake/mod.rs
+++ b/src/transport/ntcp2/handshake/mod.rs
@@ -628,4 +628,182 @@ mod tests {
             _ => panic!(),
         }
     }
+
+    #[cfg(all(test, feature = "nightly"))]
+    mod transfer {
+        use futures::*;
+        use std::cmp;
+        use std::io;
+        use std::time::Duration;
+        use test::Bencher;
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_codec::Framed;
+
+        use data::{RouterInfo, RouterSecretKeys};
+        use i2np::{Message, MessagePayload};
+        use transport::ntcp2::{
+            handshake::{IBHandshake, OBHandshake},
+            Block, Codec, Engine,
+        };
+
+        const MB: usize = 3 * 1024 * 1024;
+
+        struct Drain {
+            sock: Framed<TcpStream, Codec>,
+        }
+
+        impl Future for Drain {
+            type Item = ();
+            type Error = io::Error;
+
+            fn poll(&mut self) -> Poll<(), io::Error> {
+                loop {
+                    match self.sock.poll()? {
+                        Async::Ready(None) => return Ok(Async::Ready(())),
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        struct Transfer {
+            sock: Framed<TcpStream, Codec>,
+            rem: usize,
+            chunk: usize,
+            frame_size: usize,
+        }
+
+        impl Future for Transfer {
+            type Item = ();
+            type Error = io::Error;
+
+            fn poll(&mut self) -> Poll<(), io::Error> {
+                while self.rem > 0 {
+                    let mut frame = Vec::with_capacity(self.frame_size);
+                    for _ in 0..self.frame_size {
+                        let len = cmp::min(self.rem, self.chunk);
+                        let buf = DATA[..len].to_vec();
+
+                        frame.push(Block::Message(Message::from_payload(MessagePayload::Data(
+                            buf,
+                        ))));
+                        self.rem -= len;
+                        if self.rem == 0 {
+                            break;
+                        }
+                    }
+                    self.sock.start_send(frame)?;
+                }
+
+                self.sock.poll_complete()?;
+
+                Ok(Async::Ready(()))
+            }
+        }
+
+        static DATA: [u8; 1024] = [0; 1024];
+
+        fn one_thread(b: &mut Bencher, write_size: usize, frame_size: usize) {
+            let addr = "127.0.0.1:0".parse().unwrap();
+
+            // Generate key material
+            let alice_ri = {
+                let sk = RouterSecretKeys::new();
+                let mut ri = RouterInfo::new(sk.rid.clone());
+                ri.sign(&sk.signing_private_key);
+                ri
+            };
+            let (
+                bob_ri,
+                bob_static_public_key,
+                bob_static_private_key,
+                bob_aesobfse_key,
+                bob_aesobfse_iv,
+            ) = {
+                let sk = RouterSecretKeys::new();
+                let engine = Engine::new("127.0.0.1:0".parse().unwrap());
+                let mut ri = RouterInfo::new(sk.rid.clone());
+                ri.set_addresses(vec![engine.address()]);
+                ri.sign(&sk.signing_private_key);
+                (
+                    ri,
+                    engine.static_public_key,
+                    engine.static_private_key,
+                    sk.rid.hash().0,
+                    engine.aesobfse_iv,
+                )
+            };
+
+            b.iter(move || {
+                let listener = TcpListener::bind(&addr).unwrap();
+                let addr = listener.local_addr().unwrap();
+
+                // Spawn a single future that accepts 1 connection, Drain it and drops
+                let server = listener
+                    .incoming()
+                    .into_future()
+                    .map_err(|(e, _other_incomings)| e)
+                    .map(|(connection, _other_incomings)| connection.unwrap())
+                    .and_then(|sock| {
+                        sock.set_linger(Some(Duration::from_secs(0))).unwrap();
+                        IBHandshake::new(
+                            sock,
+                            &bob_static_private_key,
+                            &bob_aesobfse_key,
+                            &bob_aesobfse_iv,
+                        )
+                    })
+                    .and_then(|(ri, conn)| {
+                        let drain = Drain { sock: conn };
+                        drain
+                            .map(|_| ())
+                            .map_err(|e| panic!("server error: {:?}", e))
+                    });
+
+                let client = OBHandshake::new(
+                    |sa| Box::new(TcpStream::connect(&addr)),
+                    &bob_static_public_key,
+                    alice_ri.clone(),
+                    bob_ri.clone(),
+                ).unwrap()
+                    .and_then(move |(ri, conn)| Transfer {
+                        sock: conn,
+                        rem: MB,
+                        chunk: write_size,
+                        frame_size,
+                    })
+                    .map_err(|e| panic!("client err: {:?}", e));
+
+                server.join(client).wait().unwrap();
+            });
+        }
+
+        mod small_chunks {
+            use test::Bencher;
+
+            #[bench]
+            fn packed_frames(b: &mut Bencher) {
+                super::one_thread(b, 32, 800);
+            }
+
+            #[bench]
+            fn separate_frames(b: &mut Bencher) {
+                super::one_thread(b, 32, 1);
+            }
+        }
+
+        mod big_chunks {
+            use test::Bencher;
+
+            #[bench]
+            fn packed_frames(b: &mut Bencher) {
+                super::one_thread(b, 1_024, 50);
+            }
+
+            #[bench]
+            fn separate_frames(b: &mut Bencher) {
+                super::one_thread(b, 1_024, 1);
+            }
+        }
+    }
 }

--- a/src/transport/ntcp2/mod.rs
+++ b/src/transport/ntcp2/mod.rs
@@ -1,3 +1,32 @@
+//! An authenticated key agreement protocol over TCP, based on the Noise
+//! protocol framework.
+//!
+//! The Noise protocol name is `Noise_XKaesobfse+hs2+hs3_25519_ChaChaPoly_SHA256`.
+//! NTCP2 defines three extensions to `Noise_XK_25519_ChaChaPoly_SHA256`, which
+//! generally follow the guidelines in section 13 of the Noise specification:
+//!
+//! 1. Cleartext ephemeral keys are obfuscated with AES-CBC encryption using a
+//!    pre-shared (by publication in the responder's RouterInfo) key and IV.
+//!    This is indicated by the `aesobfse` modifier.
+//!
+//! 2. Random cleartext padding is appended to messages 1 and 2 (which are both
+//!    fixed-length). The cleartext padding is authenticated by calling MixHash
+//!    at the beginning of the token patterns for messages 2 and 3; this is
+//!    indicated by the `hs2+hs3` modifiers.
+//!
+//!    - Random padding is added to message 3 and data-phase messages inside
+//!      the AEAD ciphertexts, requiring no changes to the handshake protocol.
+//!      The length of message 3 is sent inside message 1.
+//!
+//! 3. A two-byte frame length field is prepended to each data-phase message.
+//!    To avoid transmitting identifiable length fields in stream, the frame
+//!    length is obfuscated by XORing a mask derived from SipHash-2-4, using
+//!    Additional Symmetric Keys derived from the final Noise chaining key. As
+//!    this occurs after the handshake is completed, it has no modifier in the
+//!    protocol name.
+//!
+//! [NTCP2 specification](https://geti2p.net/spec/ntcp2)
+
 use bytes::BytesMut;
 use cookie_factory::GenError;
 use futures::{Future, Poll, Stream};

--- a/src/transport/ntcp2/mod.rs
+++ b/src/transport/ntcp2/mod.rs
@@ -56,12 +56,12 @@ mod frame;
 mod handshake;
 
 lazy_static! {
-    pub static ref NTCP2_STYLE: I2PString = I2PString::new("NTCP2");
-    pub static ref NTCP2_VERSION: I2PString = I2PString::new("2");
-    pub static ref NTCP2_OPT_V: I2PString = I2PString::new("v");
-    pub static ref NTCP2_OPT_S: I2PString = I2PString::new("s");
-    pub static ref NTCP2_OPT_I: I2PString = I2PString::new("i");
-    pub static ref NTCP2_NOISE_PROTOCOL_NAME: &'static str =
+    static ref NTCP2_STYLE: I2PString = I2PString::new("NTCP2");
+    static ref NTCP2_VERSION: I2PString = I2PString::new("2");
+    static ref NTCP2_OPT_V: I2PString = I2PString::new("v");
+    static ref NTCP2_OPT_S: I2PString = I2PString::new("s");
+    static ref NTCP2_OPT_I: I2PString = I2PString::new("i");
+    static ref NTCP2_NOISE_PROTOCOL_NAME: &'static str =
         "Noise_XKaesobfse+hs2+hs3_25519_ChaChaPoly_SHA256";
 }
 

--- a/src/transport/session.rs
+++ b/src/transport/session.rs
@@ -1,3 +1,5 @@
+//! Common structures for managing active sessions over individual transports.
+
 use futures::{sync::mpsc, task, Async, Future, Poll, Sink, Stream};
 use std::collections::HashMap;
 use std::fmt::Debug;


### PR DESCRIPTION
A router binary will eventually be provided, but the goal is for the library to be usable as an embedded router.