### PR TITLE
Reseed router using a NetDB engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and implemented.
     - [ ] ECDSA_SHA512_P521
     - [x] Ed25519
   - Verifying
-    - [ ] DSA
+    - [x] DSA
     - [x] ECDSA_SHA256_P256
     - [x] ECDSA_SHA384_P384
     - [ ] ECDSA_SHA512_P521
@@ -39,7 +39,7 @@ and implemented.
 - NetDB
   - [x] Local storage
   - [ ] Persistence to disk
-  - [ ] Reseeding
+  - [x] Reseeding
   - [ ] Lookups
   - [ ] Publishing
   - [ ] Floodfill

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -24,6 +24,10 @@ impl LocalNetworkDatabase {
 }
 
 impl NetworkDatabase for LocalNetworkDatabase {
+    fn known_routers(&self) -> usize {
+        self.ri_ds.len()
+    }
+
     fn lookup_router_info(
         &mut self,
         key: &Hash,
@@ -81,8 +85,11 @@ mod tests {
         // TODO: replace fake key with real one
         let key = Hash([0u8; 32]);
 
+        assert_eq!(netdb.known_routers(), 0);
+
         // Storing the new RouterInfo should return no data
         assert_eq!(netdb.store_router_info(key.clone(), ri.clone()), Ok(None));
+        assert_eq!(netdb.known_routers(), 1);
 
         match netdb.lookup_router_info(&key, 100).poll() {
             Ok(Async::Ready(entry)) => assert_eq!(entry, ri),

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -2,11 +2,79 @@
 
 use futures::{future, Future};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio_timer::sleep;
 
 use data::{Hash, LeaseSet, RouterInfo};
 use router::types::NetworkDatabase;
 
 pub mod reseed;
+
+/// Minimum seconds per engine cycle.
+const ENGINE_DOWNTIME: u64 = 10;
+/// If we know fewer than this many routers, we will reseed.
+const MINIMUM_ROUTERS: usize = 50;
+
+/// Performs network database maintenance operations.
+struct Engine {
+    db: Arc<Mutex<NetworkDatabase>>,
+    reseeder: Option<reseed::HttpsReseeder>,
+}
+
+impl Engine {
+    fn new(db: Arc<Mutex<NetworkDatabase>>) -> Self {
+        Engine { db, reseeder: None }
+    }
+
+    fn start_cycle(self) -> future::FutureResult<Self, ()> {
+        trace!("Starting NetDB engine cycle");
+        future::ok(self)
+    }
+
+    fn check_reseed(self) -> Box<Future<Item = Self, Error = ()> + Send> {
+        if self.reseeder.is_none() && self.db.lock().unwrap().known_routers() < MINIMUM_ROUTERS {
+            // Reseed "synchronously" within the engine, as we can't do much without peers
+            Box::new(reseed::HttpsReseeder::new().and_then(|ris| {
+                {
+                    let mut db = self.db.lock().unwrap();
+                    for ri in ris {
+                        db.store_router_info(ri.router_id.hash(), ri).unwrap();
+                    }
+                }
+                future::ok(self)
+            }))
+        } else {
+            Box::new(future::ok(self))
+        }
+    }
+
+    fn finish_cycle(self) -> Box<Future<Item = (Self, bool), Error = ()> + Send> {
+        trace!("Finished NetDB engine cycle");
+        Box::new(
+            sleep(Duration::from_secs(ENGINE_DOWNTIME))
+                .map_err(|e| {
+                    error!("NetDB timer error: {}", e);
+                }).and_then(|_| future::ok((self, false))),
+        )
+    }
+}
+
+pub fn netdb_engine(db: Arc<Mutex<NetworkDatabase>>) -> Box<Future<Item = (), Error = ()> + Send> {
+    Box::new(future::loop_fn(Engine::new(db), |engine| {
+        engine
+            .start_cycle()
+            .and_then(|engine| engine.check_reseed())
+            .and_then(|engine| engine.finish_cycle())
+            .and_then(|(engine, done)| {
+                if done {
+                    Ok(future::Loop::Break(()))
+                } else {
+                    Ok(future::Loop::Continue(engine))
+                }
+            })
+    }))
+}
 
 /// A NetworkDatabase that never publishes data to the network.
 pub struct LocalNetworkDatabase {

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -32,6 +32,9 @@ pub trait CommSystem: OutboundMessageHandler {
 
 /// Defines the mechanism for interacting with I2P's network database.
 pub trait NetworkDatabase: Send + Sync {
+    /// Returns the number of RouterInfos that this database contains.
+    fn known_routers(&self) -> usize;
+
     /// Finds the RouterInfo stored at the given key.
     fn lookup_router_info(
         &mut self,


### PR DESCRIPTION
The NetDB engine can be extended in future to perform other management operations, like record expiry and exploration.