### PR TITLE
Validate RouterInfos when storing to local netDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +508,7 @@ dependencies = [
  "block-modes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1549,6 +1560,7 @@ dependencies = [
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ arrayref = "0.3"
 block-modes = "0.2"
 byteorder = "1.2"
 bytes = "0.4"
+chrono = "0.4"
 clap = { version = "2.32", optional = true }
 config = { version = "0.9", default-features = false, features = ["toml"] }
 cookie-factory = "0.2"

--- a/src/bin/ire.rs
+++ b/src/bin/ire.rs
@@ -162,10 +162,7 @@ fn cli_client(args: &ArgMatches) -> i32 {
 }
 
 fn cli_reseed() -> i32 {
-    let reseeder = HttpsReseeder::new().and_then(|ri| {
-        println!("Received {} RouterInfos", ri.len());
-        Ok(())
-    });
+    let reseeder = HttpsReseeder::new(mock_context());
     tokio::run(reseeder);
     0
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! [Common structures specification](https://geti2p.net/spec/common-structures)
 
+use chrono::{DateTime, Utc};
 use cookie_factory::GenError;
 use nom::{self, Needed};
 use rand::{OsRng, Rng};
@@ -121,6 +122,12 @@ impl I2PDate {
     }
 }
 
+impl fmt::Display for I2PDate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        DateTime::<Utc>::from(self.to_system_time()).fmt(f)
+    }
+}
+
 /// A UTF-8-encoded string.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct I2PString(pub String);
@@ -161,6 +168,12 @@ impl SessionTag {
 /// special cases.
 #[derive(Clone, Copy, Debug)]
 pub struct TunnelId(pub u32);
+
+impl fmt::Display for TunnelId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 /// A key certificate provides a mechanism to indicate the type of the PublicKey
 /// and SigningPublicKey in the Destination or RouterIdentity, and to package

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -115,6 +115,10 @@ impl I2PDate {
             .unwrap_or_else(|_| Duration::new(0, 0));
         I2PDate(d.as_secs() * 1_000 + u64::from(d.subsec_millis()))
     }
+
+    pub fn to_system_time(&self) -> SystemTime {
+        UNIX_EPOCH + Duration::from_millis(self.0)
+    }
 }
 
 /// A UTF-8-encoded string.
@@ -423,7 +427,7 @@ impl RouterAddress {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RouterInfo {
     pub router_id: RouterIdentity,
-    published: I2PDate,
+    pub published: I2PDate,
     addresses: Vec<RouterAddress>,
     peers: Vec<Hash>,
     options: Mapping,
@@ -465,6 +469,10 @@ impl RouterInfo {
             .filter(|a| a.addr().unwrap().is_ipv4())
             .find(|a| filter(a))
             .map(|a| (*a).clone())
+    }
+
+    pub fn network_id(&self) -> Option<&I2PString> {
+        self.options.0.get(&OPT_NET_ID)
     }
 
     pub fn from_file(path: &str) -> Result<Self, ReadError> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -25,7 +25,7 @@ use crypto::{
 pub(crate) mod frame;
 
 lazy_static! {
-    static ref OPT_NET_ID: I2PString = "netId".into();
+    pub(crate) static ref OPT_NET_ID: I2PString = "netId".into();
     static ref OPT_ROUTER_VERSION: I2PString = "router.version".into();
     static ref OPT_CAPS: I2PString = "caps".into();
 }
@@ -443,7 +443,7 @@ pub struct RouterInfo {
     pub published: I2PDate,
     addresses: Vec<RouterAddress>,
     peers: Vec<Hash>,
-    options: Mapping,
+    pub(crate) options: Mapping,
     signature: Option<Signature>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ extern crate aes;
 extern crate block_modes;
 extern crate byteorder;
 extern crate bytes;
+extern crate chrono;
 extern crate config;
 extern crate cookie_factory;
 extern crate data_encoding;

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -48,18 +48,7 @@ impl Engine {
             .unwrap();
         if enabled && self.ctx.netdb.read().unwrap().known_routers() < MINIMUM_ROUTERS {
             // Reseed "synchronously" within the engine, as we can't do much without peers
-            Box::new(reseed::HttpsReseeder::new().and_then(|ris| {
-                {
-                    let mut db = self.ctx.netdb.write().unwrap();
-                    for ri in ris {
-                        let hash = ri.router_id.hash();
-                        if let Err(e) = db.store_router_info(hash.clone(), ri) {
-                            error!("Invalid RouterInfo {} received from reseed: {}", hash, e);
-                        }
-                    }
-                }
-                future::ok(self)
-            }))
+            Box::new(reseed::HttpsReseeder::new(self.ctx.clone()).and_then(|()| future::ok(self)))
         } else {
             Box::new(future::ok(self))
         }

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -172,11 +172,7 @@ impl NetworkDatabase for LocalNetworkDatabase {
         }
         router_info_is_current(&ri)?;
 
-        debug!(
-            "Storing RouterInfo for peer {} at key {}",
-            ri.router_id.hash(),
-            key
-        );
+        debug!("Storing RouterInfo at key {}", key);
         Ok(self.ri_ds.insert(key, ri))
     }
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -42,7 +42,7 @@ impl types::InboundMessageHandler for MessageHandler {
                         .expect("Failed to store LeaseSet");
                 }
             },
-            _ => debug!("Received message from {}: {:?}", from, msg),
+            _ => debug!("Received message from {}:\n{}", from, msg),
         }
     }
 }


### PR DESCRIPTION
The reseeder now also continues until it has fetched sufficient valid RouterInfos.