### PR TITLE
Async NetDB client

### DIFF
--- a/src/bin/ire.rs
+++ b/src/bin/ire.rs
@@ -13,7 +13,7 @@ use ire::{
     data, i2np,
     netdb::reseed::HttpsReseeder,
     router::{
-        mock::{mock_context, MockDistributor},
+        mock::{mock_context, mock_netdb, MockDistributor},
         Builder,
     },
     transport,
@@ -158,7 +158,7 @@ fn cli_client(args: &ArgMatches) -> i32 {
 }
 
 fn cli_reseed() -> i32 {
-    let reseeder = HttpsReseeder::new(mock_context());
+    let reseeder = HttpsReseeder::new(mock_netdb());
     tokio::run(reseeder);
     0
 }

--- a/src/netdb/client.rs
+++ b/src/netdb/client.rs
@@ -1,0 +1,289 @@
+//! An asynchronous NetDB client.
+
+use futures::{
+    sync::{mpsc, oneshot},
+    Async, Future, Poll,
+};
+use std::fmt;
+use std::sync::{Arc, RwLock};
+use tokio_executor::spawn;
+
+use crate::{
+    data::{Hash, LeaseSet, RouterInfo},
+    router::{
+        types::{LookupError, NetworkDatabase},
+        Context,
+    },
+};
+
+pub enum Error {
+    Lookup(LookupError),
+    Closed,
+}
+
+impl From<LookupError> for Error {
+    fn from(e: LookupError) -> Self {
+        Error::Lookup(e)
+    }
+}
+
+#[cfg_attr(tarpaulin, skip)]
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Lookup(e) => write!(f, "Lookup error: {}", e),
+            Error::Closed => write!(f, "NetDB closed"),
+        }
+    }
+}
+
+pub enum Query {
+    KnownRouters(oneshot::Sender<usize>),
+    SelectClosestFloodfill(Hash, oneshot::Sender<Option<RouterInfo>>),
+    LookupRouterInfo(
+        Hash,
+        u64,
+        Option<RouterInfo>,
+        oneshot::Sender<Result<RouterInfo, LookupError>>,
+    ),
+    LookupLeaseSet(
+        Hash,
+        u64,
+        Option<Hash>,
+        oneshot::Sender<Result<LeaseSet, LookupError>>,
+    ),
+}
+
+impl Query {
+    pub(super) fn handle(self, netdb: &Arc<RwLock<dyn NetworkDatabase>>, ctx: &Arc<Context>) {
+        match self {
+            Query::KnownRouters(ret) => {
+                if ret.send(netdb.read().unwrap().known_routers()).is_err() {
+                    warn!("Completed known routers query, but client gave up");
+                }
+            }
+            Query::SelectClosestFloodfill(key, ret) => {
+                if ret
+                    .send(netdb.read().unwrap().select_closest_ff(&key))
+                    .is_err()
+                {
+                    warn!("Completed floodfill selection, but client gave up");
+                }
+            }
+            Query::LookupRouterInfo(key, timeout_ms, from_peer, ret) => {
+                spawn(
+                    netdb
+                        .write()
+                        .unwrap()
+                        .lookup_router_info(Some(ctx.clone()), &key, timeout_ms, from_peer)
+                        .then(|res| ret.send(res))
+                        .map_err(move |_| {
+                            warn!("Completed RouterInfo lookup on {}, but client gave up", key)
+                        }),
+                );
+            }
+            Query::LookupLeaseSet(key, timeout_ms, from_local_dest, ret) => {
+                spawn(
+                    netdb
+                        .write()
+                        .unwrap()
+                        .lookup_lease_set(Some(ctx.clone()), &key, timeout_ms, from_local_dest)
+                        .then(|res| ret.send(res))
+                        .map_err(move |_| {
+                            warn!("Completed LeaseSet lookup on {}, but client gave up", key)
+                        }),
+                );
+            }
+        }
+    }
+}
+
+pub struct KnownRouters {
+    client: Client,
+    response_rx: Option<oneshot::Receiver<usize>>,
+}
+
+impl KnownRouters {
+    fn new(client: Client) -> Self {
+        KnownRouters {
+            client,
+            response_rx: None,
+        }
+    }
+}
+
+impl Future for KnownRouters {
+    type Item = usize;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if self.response_rx.is_none() {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.response_rx = Some(response_rx);
+            self.client.send(Query::KnownRouters(response_tx))?;
+        }
+
+        self.response_rx
+            .as_mut()
+            .unwrap()
+            .poll()
+            .map_err(|_| Error::Closed)
+    }
+}
+
+pub struct SelectClosestFloodfill {
+    client: Client,
+    query: Option<Hash>,
+    response_rx: Option<oneshot::Receiver<Option<RouterInfo>>>,
+}
+
+impl SelectClosestFloodfill {
+    fn new(client: Client, key: Hash) -> Self {
+        SelectClosestFloodfill {
+            client,
+            query: Some(key),
+            response_rx: None,
+        }
+    }
+}
+
+impl Future for SelectClosestFloodfill {
+    type Item = Option<RouterInfo>;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let Some(key) = self.query.take() {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.response_rx = Some(response_rx);
+            self.client
+                .send(Query::SelectClosestFloodfill(key, response_tx))?;
+        }
+
+        self.response_rx
+            .as_mut()
+            .unwrap()
+            .poll()
+            .map_err(|_| Error::Closed)
+    }
+}
+
+pub struct LookupRouterInfo {
+    client: Client,
+    query: Option<(Hash, u64, Option<RouterInfo>)>,
+    response_rx: Option<oneshot::Receiver<Result<RouterInfo, LookupError>>>,
+}
+
+impl LookupRouterInfo {
+    fn new(client: Client, key: Hash, timeout_ms: u64, from_peer: Option<RouterInfo>) -> Self {
+        LookupRouterInfo {
+            client,
+            query: Some((key, timeout_ms, from_peer)),
+            response_rx: None,
+        }
+    }
+}
+
+impl Future for LookupRouterInfo {
+    type Item = RouterInfo;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let Some(query) = self.query.take() {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.response_rx = Some(response_rx);
+            self.client.send(Query::LookupRouterInfo(
+                query.0,
+                query.1,
+                query.2,
+                response_tx,
+            ))?;
+        }
+
+        match self.response_rx.as_mut().unwrap().poll() {
+            Ok(Async::Ready(Ok(ret))) => Ok(Async::Ready(ret)),
+            Ok(Async::Ready(Err(e))) => Err(e.into()),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(_) => Err(Error::Closed),
+        }
+    }
+}
+
+pub struct LookupLeaseSet {
+    client: Client,
+    query: Option<(Hash, u64, Option<Hash>)>,
+    response_rx: Option<oneshot::Receiver<Result<LeaseSet, LookupError>>>,
+}
+
+impl LookupLeaseSet {
+    fn new(client: Client, key: Hash, timeout_ms: u64, from_local_dest: Option<Hash>) -> Self {
+        LookupLeaseSet {
+            client,
+            query: Some((key, timeout_ms, from_local_dest)),
+            response_rx: None,
+        }
+    }
+}
+
+impl Future for LookupLeaseSet {
+    type Item = LeaseSet;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let Some(query) = self.query.take() {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.response_rx = Some(response_rx);
+            self.client.send(Query::LookupLeaseSet(
+                query.0,
+                query.1,
+                query.2,
+                response_tx,
+            ))?;
+        }
+
+        match self.response_rx.as_mut().unwrap().poll() {
+            Ok(Async::Ready(Ok(ret))) => Ok(Async::Ready(ret)),
+            Ok(Async::Ready(Err(e))) => Err(e.into()),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(_) => Err(Error::Closed),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Client(Arc<mpsc::UnboundedSender<Query>>);
+
+impl Client {
+    pub fn new(client_tx: mpsc::UnboundedSender<Query>) -> Self {
+        Client(Arc::new(client_tx))
+    }
+
+    fn send(&self, query: Query) -> Result<(), Error> {
+        self.0.unbounded_send(query).map_err(|_| Error::Closed)
+    }
+
+    pub fn known_routers(&self) -> KnownRouters {
+        KnownRouters::new(self.clone())
+    }
+
+    pub fn select_closest_ff(&self, key: Hash) -> SelectClosestFloodfill {
+        SelectClosestFloodfill::new(self.clone(), key)
+    }
+
+    pub fn lookup_router_info(
+        &self,
+        key: Hash,
+        timeout_ms: u64,
+        from_peer: Option<RouterInfo>,
+    ) -> LookupRouterInfo {
+        LookupRouterInfo::new(self.clone(), key, timeout_ms, from_peer)
+    }
+
+    pub fn lookup_lease_set(
+        &self,
+        key: Hash,
+        timeout_ms: u64,
+        from_local_dest: Option<Hash>,
+    ) -> LookupLeaseSet {
+        LookupLeaseSet::new(self.clone(), key, timeout_ms, from_local_dest)
+    }
+}

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -172,7 +172,7 @@ impl Engine {
             .unwrap();
         if enabled && self.ctx.netdb.read().unwrap().known_routers() < MINIMUM_ROUTERS {
             // Reseed "synchronously" within the engine, as we can't do much without peers
-            Box::new(reseed::HttpsReseeder::new(self.ctx.clone()).and_then(|()| future::ok(self)))
+            Box::new(reseed::HttpsReseeder::new(self.ctx.netdb.clone()).and_then(|()| future::ok(self)))
         } else {
             Box::new(future::ok(self))
         }

--- a/src/netdb/mod.rs
+++ b/src/netdb/mod.rs
@@ -402,9 +402,9 @@ impl NetworkDatabase for LocalNetworkDatabase {
         key: &Hash,
         timeout_ms: u64,
         _from_local_dest: Option<Hash>,
-    ) -> Box<dyn Future<Item = LeaseSet, Error = LookupError>> {
+    ) -> Box<dyn Future<Item = LeaseSet, Error = LookupError> + Send> {
         // First look for it locally, either available or pending
-        let local: Option<Box<dyn Future<Item = LeaseSet, Error = LookupError>>> =
+        let local: Option<Box<dyn Future<Item = LeaseSet, Error = LookupError> + Send>> =
             match self.ls_ds.get(key) {
                 Some(ls) => Some(Box::new(future::ok(ls.clone()))),
                 None => match self.pending_ls.get_mut(key) {

--- a/src/netdb/reseed.rs
+++ b/src/netdb/reseed.rs
@@ -209,7 +209,7 @@ impl Future for HttpsReseeder {
                         let mut db = self.netdb.write().unwrap();
                         for ri in new_ri {
                             let hash = ri.router_id.hash();
-                            if let Err(e) = db.store_router_info(hash.clone(), ri) {
+                            if let Err(e) = db.store_router_info(hash.clone(), ri, true) {
                                 error!("Invalid RouterInfo {} received from reseed: {}", hash, e);
                             } else {
                                 self.valid += 1;

--- a/src/router/mock.rs
+++ b/src/router/mock.rs
@@ -11,7 +11,7 @@ use tokio_io::IoFuture;
 use super::types::{CommSystem, Distributor, DistributorResult};
 use crate::data::{Hash, RouterAddress, RouterInfo, RouterSecretKeys};
 use crate::i2np::Message;
-use crate::netdb::LocalNetworkDatabase;
+use crate::netdb::{client::Client as NetDbClient, LocalNetworkDatabase};
 use crate::router::{types::NetworkDatabase, Context};
 
 #[derive(Clone)]
@@ -74,13 +74,13 @@ pub fn mock_context() -> Arc<Context> {
     let mut ri = RouterInfo::new(keys.rid.clone());
     ri.sign(&keys.signing_private_key);
 
-    let (tx, _) = mpsc::channel(0);
+    let (tx, _) = mpsc::unbounded();
 
     Arc::new(Context {
         config: RwLock::new(Config::default()),
         keys,
         ri: Arc::new(RwLock::new(ri)),
-        netdb: Arc::new(RwLock::new(LocalNetworkDatabase::new(tx))),
+        netdb: NetDbClient::new(tx),
         comms: Arc::new(RwLock::new(MockCommSystem::new())),
     })
 }

--- a/src/router/mock.rs
+++ b/src/router/mock.rs
@@ -12,7 +12,7 @@ use super::types::{CommSystem, Distributor, DistributorResult};
 use crate::data::{Hash, RouterAddress, RouterInfo, RouterSecretKeys};
 use crate::i2np::Message;
 use crate::netdb::LocalNetworkDatabase;
-use crate::router::Context;
+use crate::router::{types::NetworkDatabase, Context};
 
 #[derive(Clone)]
 pub struct MockDistributor {
@@ -62,6 +62,11 @@ impl CommSystem for MockCommSystem {
     ) -> Result<IoFuture<()>, (RouterInfo, Message)> {
         Ok(Box::new(future::ok(())))
     }
+}
+
+pub fn mock_netdb() -> Arc<RwLock<dyn NetworkDatabase>> {
+    let (tx, _) = mpsc::channel(0);
+    Arc::new(RwLock::new(LocalNetworkDatabase::new(tx)))
 }
 
 pub fn mock_context() -> Arc<Context> {

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -43,6 +43,7 @@ pub trait CommSystem: Send + Sync {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LookupError {
     NotFound,
+    NoPath,
     SendFailure,
     TimedOut,
     TimerFailure,
@@ -53,6 +54,7 @@ impl fmt::Display for LookupError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LookupError::NotFound => "Key not found".fmt(f),
+            LookupError::NoPath => "No path to send lookup".fmt(f),
             LookupError::SendFailure => "Send failure".fmt(f),
             LookupError::TimedOut => "Lookup timed out".fmt(f),
             LookupError::TimerFailure => "Timer failure".fmt(f),

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -118,7 +118,7 @@ pub trait NetworkDatabase: Send + Sync {
         key: &Hash,
         timeout_ms: u64,
         from_local_dest: Option<Hash>,
-    ) -> Box<dyn Future<Item = LeaseSet, Error = LookupError>>;
+    ) -> Box<dyn Future<Item = LeaseSet, Error = LookupError> + Send>;
 
     /// Stores a RouterInfo locally.
     ///

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -129,6 +129,7 @@ pub trait NetworkDatabase: Send + Sync {
         &mut self,
         key: Hash,
         ri: RouterInfo,
+        from_reseed: bool,
     ) -> Result<Option<RouterInfo>, StoreError>;
 
     /// Stores a LeaseSet locally.


### PR DESCRIPTION
This is the first part of a NetDB rewrite to interact with it globally using channels instead of an `Arc<RwLock<_>>`.