### PR TITLE
CI: Use nightly for code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.13.3'
-          args: --release --all-features --timeout 180 --out Xml
+          args: --release --timeout 180 --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0
 

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           name: Clippy (1.51.0)
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          args: --features cli --all-targets -- -D warnings


### PR DESCRIPTION
This ensures we can run the nightly-only tests.